### PR TITLE
replace usize with u64

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compound_duration"
-version = "1.2.1"
+version = "2.0.0"
 authors = ["Nicolas Embriz <nbari@tequila.io>"]
 description = "Convert seconds to compound duration (week, days, hours, minutes, seconds)"
 documentation = "https://docs.rs/compound_duration/latest/compound_duration/"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,15 +4,15 @@ use std::convert::{TryFrom, TryInto};
 use std::fmt::Debug;
 use std::ops::BitAnd;
 
-pub const NS: usize = 1;
-pub const US: usize = 1_000;
-pub const MS: usize = 1_000_000;
-pub const NANOS: usize = 1_000_000_000;
-pub const SECOND: usize = 1;
-pub const MINUTE: usize = 60;
-pub const HOUR: usize = 3_600;
-pub const DAY: usize = 86_400;
-pub const WEEK: usize = 604_800;
+pub const NS: u64 = 1;
+pub const US: u64 = 1_000;
+pub const MS: u64 = 1_000_000;
+pub const NANOS: u64 = 1_000_000_000;
+pub const SECOND: u64 = 1;
+pub const MINUTE: u64 = 60;
+pub const HOUR: u64 = 3_600;
+pub const DAY: u64 = 86_400;
+pub const WEEK: u64 = 604_800;
 
 /// Convert seconds to compound duration (days, hours, minutes, seconds)
 ///
@@ -23,21 +23,21 @@ pub const WEEK: usize = 604_800;
 ///
 /// let now = Instant::now();
 /// // do something ...
-/// println!("{}", format_dhms(now.elapsed().as_secs() as usize));
+/// println!("{}", format_dhms(now.elapsed().as_secs() as u64));
 ///
 /// // 69d10h40m
 /// println!("{}", format_dhms(6000000));
 ///```
 #[must_use]
-pub fn format_dhms<T: TryInto<usize> + TryFrom<usize> + BitAnd<Output = T>>(seconds: T) -> String
+pub fn format_dhms<T: TryInto<u64> + TryFrom<u64> + BitAnd<Output = T>>(seconds: T) -> String
 where
-    <T as TryFrom<usize>>::Error: Debug,
-    <T as TryInto<usize>>::Error: Debug,
+    <T as TryFrom<u64>>::Error: Debug,
+    <T as TryInto<u64>>::Error: Debug,
 {
-    let seconds: usize = if std::mem::size_of::<T>() <= std::mem::size_of::<usize>() {
+    let seconds: u64 = if std::mem::size_of::<T>() <= std::mem::size_of::<u64>() {
         seconds.try_into().unwrap()
     } else {
-        (seconds & usize::MAX.try_into().unwrap())
+        (seconds & u64::MAX.try_into().unwrap())
             .try_into()
             .unwrap()
     };
@@ -85,15 +85,15 @@ where
 /// println!("{}", format_wdhms(6000000));
 ///```
 #[must_use]
-pub fn format_wdhms<T: TryInto<usize> + TryFrom<usize> + BitAnd<Output = T>>(seconds: T) -> String
+pub fn format_wdhms<T: TryInto<u64> + TryFrom<u64> + BitAnd<Output = T>>(seconds: T) -> String
 where
-    <T as TryFrom<usize>>::Error: Debug,
-    <T as TryInto<usize>>::Error: Debug,
+    <T as TryFrom<u64>>::Error: Debug,
+    <T as TryInto<u64>>::Error: Debug,
 {
-    let seconds: usize = if std::mem::size_of::<T>() <= std::mem::size_of::<usize>() {
+    let seconds: u64 = if std::mem::size_of::<T>() <= std::mem::size_of::<u64>() {
         seconds.try_into().unwrap()
     } else {
-        (seconds & usize::MAX.try_into().unwrap())
+        (seconds & u64::MAX.try_into().unwrap())
             .try_into()
             .unwrap()
     };
@@ -147,18 +147,18 @@ where
 /// use std::time::Instant;
 ///
 /// let now = Instant::now();
-/// println!("{}", format_ns(now.elapsed().as_nanos() as usize));
+/// println!("{}", format_ns(now.elapsed().as_nanos() as u64));
 ///```
 #[must_use]
-pub fn format_ns<T: TryInto<usize> + TryFrom<usize> + BitAnd<Output = T>>(nanos: T) -> String
+pub fn format_ns<T: TryInto<u64> + TryFrom<u64> + BitAnd<Output = T>>(nanos: T) -> String
 where
-    <T as TryFrom<usize>>::Error: Debug,
-    <T as TryInto<usize>>::Error: Debug,
+    <T as TryFrom<u64>>::Error: Debug,
+    <T as TryInto<u64>>::Error: Debug,
 {
-    let nanos: usize = if std::mem::size_of::<T>() <= std::mem::size_of::<usize>() {
+    let nanos: u64 = if std::mem::size_of::<T>() <= std::mem::size_of::<u64>() {
         nanos.try_into().unwrap()
     } else {
-        (nanos & usize::MAX.try_into().unwrap()).try_into().unwrap()
+        (nanos & u64::MAX.try_into().unwrap()).try_into().unwrap()
     };
     let mut compound_duration = String::new();
     if nanos == 0 {
@@ -231,7 +231,7 @@ mod tests {
         assert_eq!(format_dhms(7259), "2h59s");
         assert_eq!(format_dhms(604_800), "7d");
         assert_eq!(format_dhms(6_000_000), "69d10h40m");
-        assert_eq!(format_dhms(4_294_967_295_usize), "49710d6h28m15s");
+        assert_eq!(format_dhms(4_294_967_295_u64), "49710d6h28m15s");
     }
 
     #[test]
@@ -245,37 +245,37 @@ mod tests {
         assert_eq!(format_wdhms(7259), "2h59s");
         assert_eq!(format_wdhms(604_800), "1w");
         assert_eq!(format_wdhms(6_000_000), "9w6d10h40m");
-        assert_eq!(format_wdhms(4_294_967_295_usize), "7101w3d6h28m15s");
+        assert_eq!(format_wdhms(4_294_967_295_u64), "7101w3d6h28m15s");
     }
 
     #[test]
     fn test_format_ns() {
-        assert_eq!(format_ns(3_000_129_723_usize), "3s129\u{b5}s723ns");
-        assert_eq!(format_ns(100_000_000_000_000_000_usize), "1157d9h46m40s");
-        assert_eq!(format_ns(100_000_000_000_000_001_usize), "1157d9h46m40s1ns");
+        assert_eq!(format_ns(3_000_129_723_u64), "3s129\u{b5}s723ns");
+        assert_eq!(format_ns(100_000_000_000_000_000_u64), "1157d9h46m40s");
+        assert_eq!(format_ns(100_000_000_000_000_001_u64), "1157d9h46m40s1ns");
         assert_eq!(
-            format_ns(100_000_000_000_001_001_usize),
+            format_ns(100_000_000_000_001_001_u64),
             "1157d9h46m40s1\u{b5}s1ns"
         );
         assert_eq!(
-            format_ns(100_000_000_000_100_001_usize),
+            format_ns(100_000_000_000_100_001_u64),
             "1157d9h46m40s100\u{b5}s1ns"
         );
         assert_eq!(
-            format_ns(100_000_000_010_100_001_usize),
+            format_ns(100_000_000_010_100_001_u64),
             "1157d9h46m40s10ms100\u{b5}s1ns"
         );
         assert_eq!(
-            format_ns(100_000_000_010_000_001_usize),
+            format_ns(100_000_000_010_000_001_u64),
             "1157d9h46m40s10ms1ns"
         );
-        assert_eq!(format_ns(10_000_000_000_000_000_usize), "115d17h46m40s");
-        assert_eq!(format_ns(1_000_000_000_000_000_usize), "11d13h46m40s");
-        assert_eq!(format_ns(100_000_000_000_000_usize), "1d3h46m40s");
-        assert_eq!(format_ns(10_000_000_000_000_usize), "2h46m40s");
-        assert_eq!(format_ns(1_000_000_000_000_usize), "16m40s");
-        assert_eq!(format_ns(100_000_000_000_usize), "1m40s");
-        assert_eq!(format_ns(100_000_000_010_usize), "1m40s10ns");
+        assert_eq!(format_ns(10_000_000_000_000_000_u64), "115d17h46m40s");
+        assert_eq!(format_ns(1_000_000_000_000_000_u64), "11d13h46m40s");
+        assert_eq!(format_ns(100_000_000_000_000_u64), "1d3h46m40s");
+        assert_eq!(format_ns(10_000_000_000_000_u64), "2h46m40s");
+        assert_eq!(format_ns(1_000_000_000_000_u64), "16m40s");
+        assert_eq!(format_ns(100_000_000_000_u64), "1m40s");
+        assert_eq!(format_ns(100_000_000_010_u64), "1m40s10ns");
         assert_eq!(format_ns(1_000_000_000), "1s");
         assert_eq!(format_ns(100_000_000), "100ms");
         assert_eq!(format_ns(10_000_000), "10ms");


### PR DESCRIPTION
as usize is 32-bit on 32-bit architectures.

Currently the project doesn't build on any 32-bit architecture: https://buildd.debian.org/status/package.php?p=rust-compound-duration

With problems like this:
```
warning: this arithmetic operation will overflow
   --> src/lib.rs:169:26
    |
169 |     let mut ns = nanos % (DAY * NANOS);
    |                          ^^^^^^^^^^^^^ attempt to compute `86400_usize * 1000000000_usize`, which would overflow
    |
    = note: `#[warn(arithmetic_overflow)]` on by default
```

It looks to me like this breaks your public api, so I also bumped the major version to 2.